### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2024] [Dave DeLong]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Saw in the iOS Folks Slack that people were asking about licensing. 

I don't know what license you'd prefer – I was actually torn between this and the [Unlicense](https://choosealicense.com/licenses/unlicense/) (which effectively is a public domain dedication with no copyrights held or attributions required), but opted for a standard MIT license instead.

Let me know if you'd prefer something else!

I know that if I wanted to use any of this code for GitHub Mobile, for example, I would be strictly unable to as a result of no licensing on this repository. 